### PR TITLE
SWE-agent[bot] PR to fix: UI Feedback: This progress bar should be blue and not green.

### DIFF
--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -161,7 +161,7 @@ export default function Hero() {
             </div>
             <div className="w-full h-2 bg-white rounded-full overflow-hidden mb-2">
               <div 
-                className="h-full bg-[#1ca152] rounded-full transition-all duration-500" 
+                className="h-full bg-[#2563eb] rounded-full transition-all duration-500" 
                 style={{ width: `${progressPercentage}%` }}
               ></div>
             </div>

--- a/verify_progress_bar_color.py
+++ b/verify_progress_bar_color.py
@@ -1,0 +1,16 @@
+import sys
+
+FILE = 'frontend/src/components/Hero.tsx'
+EXPECTED = 'bg-[#2563eb]'
+UNEXPECTED = 'bg-[#1ca152]'
+
+with open(FILE) as f:
+    content = f.read()
+
+if EXPECTED in content and UNEXPECTED not in content:
+    print('PASS: Progress bar is blue (#2563eb) and not green (#1ca152).')
+    sys.exit(0)
+else:
+    print('FAIL: Progress bar color is incorrect.')
+    sys.exit(1)
+


### PR DESCRIPTION
This is a PR opened by AI tool [SWE Agent](https://github.com/SWE-agent/SWE-agent/) to close [#11](https://github.com/akhatua2/wikifix/issues/11) (UI Feedback: This progress bar should be blue and not green.).

Closes #11.

<details>
<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>

**🧑‍🚒 Response (0)**: 

**👀‍ Observation (0)**:
```
/akhatua2__wikifix:
total 18
-rw-r--r-- 1 root root  3834 Jun 13 17:34 README.md
-rw-r--r-- 1 root root 11998 Jun 13 17:34 WIKIPEDIA_HIGHLIGHTING_SYSTEM.md
drwxr-xr-x 8 root root    10 Jun 13 17:34 backend
drwxr-xr-x 4 root root    10 Jun 13 17:34 frontend
-rwxr-xr-x 1 root root   577 Jun 13 17:34 start.sh

/akhatua2__wikifix/backend:
total 400
-rw-r--r-- 1 root root   2560 Jun 13 17:34 _fake.py
drwxr-xr-x 4 root root     10 Jun 13 17:34 alembic
-rw-r--r-- 1 root root   4678 Jun 13 17:34 alembic.ini
drwxr-xr-x 2 root root     57 Jun 13 17:34 api
-rw-r--r-- 1 root root    514 Jun 13 17:34 clone.py
drwxr-xr-x 2 root root     74 Jun 13 17:34 db
-rw-r--r-- 1 root root   5407 Jun 13 17:34 download_wikipedia.py
-rw-r--r-- 1 root root 267309 Jun 13 17:34 inconsistent_claims.json
-rw-r--r-- 1 root root  21186 Jun 13 17:34 main.py
drwxr-xr-x 2 root root    110 Jun 13 17:34 preprocessing
-rw-r--r-- 1 root root   2607 Jun 13 17:34 proxy.py
-rw-r--r-- 1 root root    487 Jun 13 17:34 pyproject.toml
drwxr-xr-x 3 root root     10 Jun 13 17:34 saved_site
drwxr-xr-x 3 root root     10 Jun 13 17:34 utils
-rw-r--r-- 1 root root  99044 Jun 13 17:34 uv.lock

/akhatua2__wikifix/backend/alembic:
total 5
-rw-r--r-- 1 root root   38 Jun 13 17:34 README
drwxr-xr-x 2 root root   41 Jun 13 17:34 __pycache__
-rw-r--r-- 1 root root 2326 Jun 13 17:34 env.py
-rw-r--r-- 1 root root  689 Jun 13 17:34 script.py.mako
drwxr-xr-x 3 root root   10 Jun 13 17:34 versions

/akhatua2__wikifix/backend/alembic/__pycache__:
total 3
-rw-r--r-- 1 root root 3019 Jun 13 17:34 env.cpython-312.pyc

/akhatua2__wikifix/backend/alembic/versions:
total 8
-rw-r--r-- 1 root root  961 Jun 13 17:34 54027bef38e7_add_topics_and_languages_to_user.py
drwxr-xr-x 2 root root 4096 Jun 13 17:34 __pycache__
-rw-r--r-- 1 root root 1711 Jun 13 17:34 a005a366cbfe_add_referral_columns.py
-rw-r--r-- 1 root root  835 Jun 13 17:34 b209a991f11f_add_updated_at_to_users.py

/akhatua2__wikifix/backend/alembic/versions/__pycache__:
total 7
-rw-r--r-- 1 root root 1537 Jun 13 17:34 54027bef38e7_add_topics_and_languages_to_user.cpython-312.pyc
-rw-r--r-- 1 root root 2467 Jun 13 17:34 a005a366cbfe_add_referral_columns.cpython-312.pyc
-rw-r--r-- 1 root root 1655 Jun 13 17:34 b209a991f11f_add_updated_at_to_users.cpython-312.pyc

/akhatua2__wikifix/backend/api:
total 8
-rw-r--r-- 1 root root    0 Jun 13 17:34 __init__.py
-rw-r--r-- 1 root root 7511 Jun 13 17:34 wikipedia.py

/akhatua2__wikifix/backend/db:
total 16
-rw-r--r-- 1 root root  656 Jun 13 17:34 db.py
-rw-r--r-- 1 root root 7391 Jun 13 17:34 tasks_ops.py
-rw-r--r-- 1 root root 7134 Jun 13 17:34 user_ops.py

/akhatua2__wikifix/backend/preprocessing:
total 41
-rw-r--r-- 1 root root    57 Jun 13 17:34 __init__.py
-rw-r--r-- 1 root root 25401 Jun 13 17:34 highlighting.py
-rw-r--r-- 1 root root 12358 Jun 13 17:34 pipeline.py
-rwxr-xr-x 1 root root  2758 Jun 13 17:34 run_pipeline.py

/akhatua2__wikifix/backend/saved_site:
total 1
drwxr-xr-x 3 root root 10 Jun 13 17:34 en.wikipedia.org

/akhatua2__wikifix/backend/saved_site/en.wikipedia.org:
total 32
-rw-r--r-- 1 root root 27889 Jun 13 17:34 robots.txt
drwxr-xr-x 2 root root  4096 Jun 13 17:34 wiki

/akhatua2__wikifix/backend/saved_site/en.wikipedia.org/wiki:
total 13978
-rw-r--r-- 1 root root  480773 Jun 13 17:34  2024_in_California.html
-rw-r--r-- 1 root root  774459 Jun 13 17:34  Berlin_Wall.html
-rw-r--r-- 1 root root   99349 Jun 13 17:34 'Berlin_Wall_Monument_(Chicago).html'
-rw-r--r-- 1 root root 1993996 Jun 13 17:34  COVID-19.html
-rw-r--r-- 1 root root 2032658 Jun 13 17:34  COVID-19_pandemic.html
-rw-r--r-- 1 root root 1652731 Jun 13 17:34  COVID-19_pandemic_by_country_and_territory.html
-rw-r--r-- 1 root root 1234607 Jun 13 17:34  COVID-19_pandemic_deaths.html
-rw-r--r-- 1 root root  664154 Jun 13 17:34  CRISPR.html
-rw-r--r-- 1 root root   75652 Jun 13 17:34  Eukaryotic_chromosome_fine_structure.html
-rw-r--r-- 1 root root  433841 Jun 13 17:34  Fall_of_the_Berlin_Wall.html
-rw-r--r-- 1 root root  107071 Jun 13 17:34  Interspersed_repeat.html
-rw-r--r-- 1 root root  195128 Jun 13 17:34  Inverted_repeat.html
-rw-r--r-- 1 root root 1084080 Jun 13 17:34  James_Webb_Space_Telescope.html
-rw-r--r-- 1 root root  172493 Jun 13 17:34  James_Webb_Space_Telescope_sunshield.html
-rw-r--r-- 1 root root  638566 Jun 13 17:34  Media_coverage_of_the_COVID-19_pandemic.html
-rw-r--r-- 1 root root  140513 Jun 13 17:34  OTE_Pathfinder.html
-rw-r--r-- 1 root root  358779 Jun 13 17:34  Potsdamer_Platz.html
-rw-r--r-- 1 root root  500829 Jun 13 17:34  Remdesivir.html
-rw-r--r-- 1 root root  237477 Jun 13 17:34 'Repeated_sequence_(DNA).html'
-rw-r--r-- 1 root root  515997 Jun 13 17:34  Sanofi–GSK_COVID-19_vaccine.html
-rw-r--r-- 1 root root  185712 Jun 13 17:34  Sustainable_Development_Goal_15.html
-rw-r--r-- 1 root root   88965 Jun 13 17:34 'The_Rotunda_(Baltimore).html'
-rw-r--r-- 1 root root  535622 Jun 13 17:34  Timeline_of_the_COVID-19_pandemic.html
-rw-r--r-- 1 root root  102451 Jun 13 17:34  Variable_number_tandem_repeat.html

/akhatua2__wikifix/backend/utils:
total 5
-rw-r--r-- 1 root root    0 Jun 13 17:34 __init__.py
drwxr-xr-x 2 root root   73 Jun 13 17:34 __pycache__
-rw-r--r-- 1 root root 4385 Jun 13 17:34 url_mapping.py

/akhatua2__wikifix/backend/utils/__pycache__:
total 6
-rw-r--r-- 1 root root  151 Jun 13 17:34 __init__.cpython-312.pyc
-rw-r--r-- 1 root root 4684 Jun 13 17:34 url_mapping.cpython-312.pyc

/akhatua2__wikifix/frontend:
total 227
-rw-r--r-- 1 root root   1450 Jun 13 17:34 README.md
-rw-r--r-- 1 root root   1507 Jun 13 17:34 design-principles.md
-rw-r--r-- 1 root root    393 Jun 13 17:34 eslint.config.mjs
-rw-r--r-- 1 root root    133 Jun 13 17:34 next.config.ts
-rw-r--r-- 1 root root 223303 Jun 13 17:34 package-lock.json
-rw-r--r-- 1 root root    760 Jun 13 17:34 package.json
-rw-r--r-- 1 root root    135 Jun 13 17:34 postcss.config.mjs
drwxr-xr-x 5 root root      6 Jun 13 17:34 public
drwxr-xr-x 8 root root      6 Jun 13 17:34 src
-rw-r--r-- 1 root root    393 Jun 13 17:34 tailwind.config.ts
-rw-r--r-- 1 root root    602 Jun 13 17:34 tsconfig.json

/akhatua2__wikifix/frontend/public:
total 6879
-rw-r--r-- 1 root root   79343 Jun 13 17:34 art.png
drwxr-xr-x 2 root root      58 Jun 13 17:34 badges
drwxr-xr-x 2 root root      74 Jun 13 17:34 cups
-rw-r--r-- 1 root root     391 Jun 13 17:34 file.svg
-rw-r--r-- 1 root root   83831 Jun 13 17:34 geography.png
-rw-r--r-- 1 root root    1035 Jun 13 17:34 globe.svg
-rw-r--r-- 1 root root 2882597 Jun 13 17:34 hero.png
-rw-r--r-- 1 root root  120890 Jun 13 17:34 history.png
-rw-r--r-- 1 root root 1763467 Jun 13 17:34 human_ai.png
-rw-r--r-- 1 root root   73549 Jun 13 17:34 literature.png
-rw-r--r-- 1 root root   47287 Jun 13 17:34 music.png
-rw-r--r-- 1 root root    1375 Jun 13 17:34 next.svg
-rw-r--r-- 1 root root   13517 Jun 13 17:34 oval_labs.png
drwxr-xr-x 2 root root     117 Jun 13 17:34 process
-rw-r--r-- 1 root root   60646 Jun 13 17:34 science.png
-rw-r--r-- 1 root root   78400 Jun 13 17:34 sports.png
-rw-r--r-- 1 root root  101315 Jun 13 17:34 stanford.png
-rw-r--r-- 1 root root   34173 Jun 13 17:34 stanford_logo.png
-rw-r--r-- 1 root root   76124 Jun 13 17:34 technology.png
-rw-r--r-- 1 root root     128 Jun 13 17:34 vercel.svg
-rw-r--r-- 1 root root 1618765 Jun 13 17:34 wikifix.png
-rw-r--r-- 1 root root     385 Jun 13 17:34 window.svg

/akhatua2__wikifix/frontend/public/badges:
total 4093
-rw-r--r-- 1 root root 1413023 Jun 13 17:34 bronze.png
-rw-r--r-- 1 root root 1324490 Jun 13 17:34 gold.png
-rw-r--r-- 1 root root 1452986 Jun 13 17:34 silver.png

/akhatua2__wikifix/frontend/public/cups:
total 4018
-rw-r--r-- 1 root root 1267292 Jun 13 17:34 first.png
-rw-r--r-- 1 root root 1431746 Jun 13 17:34 second.png
-rw-r--r-- 1 root root 1414191 Jun 13 17:34 third.png

/akhatua2__wikifix/frontend/public/process:
total 805
-rw-r--r-- 1 root root 173461 Jun 13 17:34 agent.png
-rw-r--r-- 1 root root 173491 Jun 13 17:34 find.png
-rw-r--r-- 1 root root 209480 Jun 13 17:34 review.png
-rw-r--r-- 1 root root 117019 Jun 13 17:34 reward.png
-rw-r--r-- 1 root root 149001 Jun 13 17:34 submit.png

/akhatua2__wikifix/frontend/src:
total 3
drwxr-xr-x 7 root root  10 Jun 13 17:34 app
drwxr-xr-x 2 root root 139 Jun 13 17:34 components
drwxr-xr-x 2 root root  72 Jun 13 17:34 contexts
drwxr-xr-x 2 root root  37 Jun 13 17:34 hooks
drwxr-xr-x 2 root root  29 Jun 13 17:34 types
drwxr-xr-x 2 root root  34 Jun 13 17:34 utils

/akhatua2__wikifix/frontend/src/app:
total 31
drwxr-xr-x 2 root root    30 Jun 13 17:34 about
-rw-r--r-- 1 root root 25931 Jun 13 17:34 favicon.ico
-rw-r--r-- 1 root root   345 Jun 13 17:34 globals.css
-rw-r--r-- 1 root root  1329 Jun 13 17:34 layout.tsx
drwxr-xr-x 2 root root    30 Jun 13 17:34 leaderboard
-rw-r--r-- 1 root root   191 Jun 13 17:34 metadata.ts
drwxr-xr-x 6 root root    10 Jun 13 17:34 onboarding
-rw-r--r-- 1 root root    94 Jun 13 17:34 page.tsx
drwxr-xr-x 2 root root    30 Jun 13 17:34 profile
drwxr-xr-x 4 root root    10 Jun 13 17:34 tasks

/akhatua2__wikifix/frontend/src/app/about:
total 11
-rw-r--r-- 1 root root 10921 Jun 13 17:34 page.tsx

/akhatua2__wikifix/frontend/src/app/leaderboard:
total 4
-rw-r--r-- 1 root root 3151 Jun 13 17:34 page.tsx

/akhatua2__wikifix/frontend/src/app/onboarding:
total 2
drwxr-xr-x 2 root root 30 Jun 13 17:34 finish
drwxr-xr-x 2 root root 30 Jun 13 17:34 language
drwxr-xr-x 2 root root 30 Jun 13 17:34 topics
drwxr-xr-x 2 root root 30 Jun 13 17:34 username

/akhatua2__wikifix/frontend/src/app/onboarding/finish:
total 6
-rw-r--r-- 1 root root 5353 Jun 13 17:34 page.tsx

/akhatua2__wikifix/frontend/src/app/onboarding/language:
total 10
-rw-r--r-- 1 root root 9912 Jun 13 17:34 page.tsx

/akhatua2__wikifix/frontend/src/app/onboarding/topics:
total 9
-rw-r--r-- 1 root root 8693 Jun 13 17:34 page.tsx

/akhatua2__wikifix/frontend/src/app/onboarding/username:
total 10
-rw-r--r-- 1 root root 9252 Jun 13 17:34 page.tsx

/akhatua2__wikifix/frontend/src/app/profile:
total 23
-rw-r--r-- 1 root root 22543 Jun 13 17:34 page.tsx

/akhatua2__wikifix/frontend/src/app/tasks:
total 3
drwxr-xr-x 2 root root   30 Jun 13 17:34 '[taskId]'
drwxr-xr-x 2 root root   30 Jun 13 17:34  all
-rw-r--r-- 1 root root 1496 Jun 13 17:34  page.tsx

'/akhatua2__wikifix/frontend/src/app/tasks/[taskId]':
total 19
-rw-r--r-- 1 root root 18599 Jun 13 17:34 page.tsx

/akhatua2__wikifix/frontend/src/app/tasks/all:
total 5
-rw-r--r-- 1 root root 4264 Jun 13 17:34 page.tsx

/akhatua2__wikifix/frontend/src/components:
total 38
-rw-r--r-- 1 root root  7497 Jun 13 17:34 Hero.tsx
-rw-r--r-- 1 root root  4870 Jun 13 17:34 ImpactSection.tsx
-rw-r--r-- 1 root root 15049 Jun 13 17:34 Navbar.tsx
-rw-r--r-- 1 root root  3010 Jun 13 17:34 TaskSkeleton.tsx
-rw-r--r-- 1 root root  7305 Jun 13 17:34 WikipediaEmbed.tsx

/akhatua2__wikifix/frontend/src/contexts:
total 4
-rw-r--r-- 1 root root 1733 Jun 13 17:34 ConfettiContext.tsx
-rw-r--r-- 1 root root 1611 Jun 13 17:34 ProgressContext.tsx

/akhatua2__wikifix/frontend/src/hooks:
total 2
-rw-r--r-- 1 root root 2024 Jun 13 17:34 useAnalytics.ts

/akhatua2__wikifix/frontend/src/types:
total 3
-rw-r--r-- 1 root root 2159 Jun 13 17:34 task.ts

/akhatua2__wikifix/frontend/src/utils:
total 3
-rw-r--r-- 1 root root 2445 Jun 13 17:34 analytics.ts
```

---

**🧑‍🚒 Response (1)**: 

**👀‍ Observation (1)**:
```
/akhatua2__wikifix/frontend/src/app/layout.tsx:6:import { ProgressProvider } from '@/contexts/ProgressContext';
/akhatua2__wikifix/frontend/src/app/layout.tsx:25:          <ProgressProvider>
/akhatua2__wikifix/frontend/src/app/layout.tsx:29:          </ProgressProvider>
/akhatua2__wikifix/frontend/src/app/onboarding/language/page.tsx:114:      {/* Progress Tracker */}
/akhatua2__wikifix/frontend/src/app/onboarding/topics/page.tsx:132:      {/* Progress Tracker */}
/akhatua2__wikifix/frontend/src/app/onboarding/username/page.tsx:169:      {/* Progress Tracker */}
/akhatua2__wikifix/frontend/src/app/tasks/[taskId]/page.tsx:9:import { useProgress } from '@/contexts/ProgressContext';
/akhatua2__wikifix/frontend/src/app/tasks/[taskId]/page.tsx:33:  const { completedTasks, updateCompletedTasks } = useProgress();
/akhatua2__wikifix/frontend/src/app/tasks/[taskId]/page.tsx:255:        {/* Progress Bar and Profile Section */}
/akhatua2__wikifix/frontend/src/app/tasks/[taskId]/page.tsx:303:      {/* Progress Bar and Profile Section */}
/akhatua2__wikifix/frontend/src/app/tasks/all/page.tsx:94:                    task.status === 'IN_PROGRESS' ? 'bg-[#dce8f3] text-[#121416]' :
/akhatua2__wikifix/frontend/src/components/Hero.tsx:126:  // Calculate progress percentage (assuming 100 is the goal)
/akhatua2__wikifix/frontend/src/components/Hero.tsx:127:  const progressPercentage = stats ? Math.min((stats.total_completed_tasks / 100) * 100, 100) : 0;
/akhatua2__wikifix/frontend/src/components/Hero.tsx:156:              <span className="text-xs text-[#121416] font-medium">{Math.round(progressPercentage)}% complete</span>
/akhatua2__wikifix/frontend/src/components/Hero.tsx:165:                style={{ width: `${progressPercentage}%` }}
/akhatua2__wikifix/frontend/src/contexts/ProgressContext.tsx:4:interface ProgressContextType {
/akhatua2__wikifix/frontend/src/contexts/ProgressContext.tsx:9:const ProgressContext = createContext<ProgressContextType | undefined>(undefined);
/akhatua2__wikifix/frontend/src/contexts/ProgressContext.tsx:11:export function ProgressProvider({ children }: { children: React.ReactNode }) {
/akhatua2__wikifix/frontend/src/contexts/ProgressContext.tsx:39:    <ProgressContext.Provider value={{ completedTasks, updateCompletedTasks }}>
/akhatua2__wikifix/frontend/src/contexts/ProgressContext.tsx:41:    </ProgressContext.Provider>
/akhatua2__wikifix/frontend/src/contexts/ProgressContext.tsx:45:export function useProgress() {
/akhatua2__wikifix/frontend/src/contexts/ProgressContext.tsx:46:  const context = useContext(ProgressContext);
/akhatua2__wikifix/frontend/src/contexts/ProgressContext.tsx:48:    throw new Error('useProgress must be used within a ProgressProvider');
```

---

**🧑‍🚒 Response (2)**: 

**👀‍ Observation (2)**:
```
/akhatua2__wikifix/frontend/src/app/onboarding/username/page.tsx:205:                 <svg className="h-5 w-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
```

---

**🧑‍🚒 Response (3)**: 

**👀‍ Observation (3)**:
```
/akhatua2__wikifix/frontend/src/app/layout.tsx:4:import Navbar from '../components/Navbar';
/akhatua2__wikifix/frontend/src/app/layout.tsx:26:            <NavbarWrapper>
/akhatua2__wikifix/frontend/src/app/layout.tsx:28:            </NavbarWrapper>
/akhatua2__wikifix/frontend/src/app/layout.tsx:37:function NavbarWrapper({ children }: { children: React.ReactNode }) {
/akhatua2__wikifix/frontend/src/app/layout.tsx:44:      {!isTaskPage && !isOnboardingPage && <Navbar />}
/akhatua2__wikifix/frontend/src/app/tasks/[taskId]/page.tsx:255:        {/* Progress Bar and Profile Section */}
/akhatua2__wikifix/frontend/src/app/tasks/[taskId]/page.tsx:303:      {/* Progress Bar and Profile Section */}
/akhatua2__wikifix/frontend/src/components/Navbar.tsx:18:export default function Navbar() {
/akhatua2__wikifix/frontend/src/components/Navbar.tsx:121:      source: 'navbar',
/akhatua2__wikifix/frontend/src/components/Navbar.tsx:128:      "width=500,height=600,scrollbars=yes,resizable=yes"
/akhatua2__wikifix/frontend/src/components/Navbar.tsx:133:      trackAction('login_popup_blocked', { source: 'navbar' });
/akhatua2__wikifix/frontend/src/components/Navbar.tsx:155:          source: 'navbar',
/akhatua2__wikifix/frontend/src/components/Navbar.tsx:171:          source: 'navbar' 
/akhatua2__wikifix/frontend/src/components/Navbar.tsx:344:            {/* Completed Tasks Bar */}
```

---

**🧑‍🚒 Response (4)**: 

**👀‍ Observation (4)**:
```
/akhatua2__wikifix/frontend/src/components/Hero.tsx:153:          <div className="rounded-2xl border border-[#f1f2f4] p-6 mb-6 bg-[#f1f2f4]">
/akhatua2__wikifix/frontend/src/components/Hero.tsx:200:            className="w-full h-auto rounded-2xl"
/akhatua2__wikifix/frontend/src/components/ImpactSection.tsx:18:          <div className="bg-white p-8 rounded-2xl shadow-sm">
/akhatua2__wikifix/frontend/src/components/ImpactSection.tsx:33:          <div className="bg-white p-8 rounded-2xl shadow-sm">
/akhatua2__wikifix/frontend/src/components/ImpactSection.tsx:48:          <div className="bg-white p-8 rounded-2xl shadow-sm">
/akhatua2__wikifix/frontend/src/components/ImpactSection.tsx:65:        <div className="mt-16 bg-white p-8 rounded-2xl shadow-sm">
```

---

**🧑‍🚒 Response (5)**: 

**👀‍ Observation (5)**:
```
Traceback (most recent call last):
  File "/root/tools/edit_anthropic/bin/str_replace_editor", line 18, in <module>
    from registry import registry as REGISTRY
ModuleNotFoundError: No module named 'registry'
```

---

**🧑‍🚒 Response (6)**: 

**👀‍ Observation (6)**:
```
Traceback (most recent call last):
  File "/root/tools/edit_anthropic/bin/str_replace_editor", line 18, in <module>
    from registry import registry as REGISTRY
ModuleNotFoundError: No module named 'registry'
```

---

**🧑‍🚒 Response (7)**: 

**👀‍ Observation (7)**:
```
className="rounded-full"
              />
            </span>
          </div>
          <h1 className="text-5xl font-bold text-[#121416] mb-6 leading-tight tracking-tight">
            {userName ? `Hi ${userName}, Help Improve Wikipedia` : 'Help Improve Wikipedia'}
          </h1>
          <p className="text-lg text-[#121416] mb-8 font-normal">
            Join Stanford researchers in fixing millions of inconsistencies in Wikipedia. 
            Your contributions will directly improve the world&apos;s largest knowledge base 
            and earn you rewards for your impact.
          </p>
          <div className="rounded-2xl border border-[#f1f2f4] p-6 mb-6 bg-[#f1f2f4]">
            <div className="flex items-center justify-between mb-2">
              <span className="font-bold text-[#121416]">Goal: Fix 100 Inconsistencies</span>
              <span className="text-xs text-[#121416] font-medium">{Math.round(progressPercentage)}% complete</span>
            </div>
            <div className="text-xs text-[#121416] mb-1 flex justify-between">
              <span>{stats?.total_completed_tasks || 0} tasks completed</span>
              <span>{stats?.total_points_awarded || 0} points earned</span>
            </div>
            <div className="w-full h-2 bg-white rounded-full overflow-hidden mb-2">
              <div 
                className="h-full bg-[#1ca152] rounded-full transition-all duration-500" 
                style={{ width: `${progressPercentage}%` }}
              ></div>
            </div>
            <div className="flex items-center gap-2 text-xs mt-1 text-[#121416]">
              {isLoading ? (
                'Loading community stats...'
              ) : (
                <>
                  Join {stats?.total_users || 0}+ contributors making a real impact on Wikipedia.
                </>
              )}
            </div>
          </div>
          <div className="flex gap-4">
            <button 
              onClick={handleStartContributing}
```

---

**🧑‍🚒 Response (8)**: 

**👀‍ Observation (8)**:
```
"use client";
import React, { useEffect, useState } from "react";
import { useRouter } from "next/navigation";
import { useAnalytics } from '@/hooks/useAnalytics';
import ImpactSection from './ImpactSection';
import Image from 'next/image';

interface PlatformStats {
  total_users: number;
  total_completed_tasks: number;
  total_points_awarded: number;
  average_points_per_user: number;
}

export default function Hero() {
  const [stats, setStats] = useState<PlatformStats | null>(null);
  const [isLoading, setIsLoading] = useState(true);
  const [isLoggedIn, setIsLoggedIn] = useState(false);
  const [userName, setUserName] = useState<string | null>(null);
  const { trackClick, trackAction, trackPage } = useAnalytics();
```

---

**🧑‍🚒 Response (9)**: 

**👀‍ Observation (9)**:
```
className="rounded-full"
              />
            </span>
          </div>
          <h1 className="text-5xl font-bold text-[#121416] mb-6 leading-tight tracking-tight">
            {userName ? `Hi ${userName}, Help Improve Wikipedia` : 'Help Improve Wikipedia'}
          </h1>
          <p className="text-lg text-[#121416] mb-8 font-normal">
            Join Stanford researchers in fixing millions of inconsistencies in Wikipedia. 
            Your contributions will directly improve the world&apos;s largest knowledge base 
            and earn you rewards for your impact.
          </p>
          <div className="rounded-2xl border border-[#f1f2f4] p-6 mb-6 bg-[#f1f2f4]">
            <div className="flex items-center justify-between mb-2">
              <span className="font-bold text-[#121416]">Goal: Fix 100 Inconsistencies</span>
              <span className="text-xs text-[#121416] font-medium">{Math.round(progressPercentage)}% complete</span>
            </div>
            <div className="text-xs text-[#121416] mb-1 flex justify-between">
              <span>{stats?.total_completed_tasks || 0} tasks completed</span>
              <span>{stats?.total_points_awarded || 0} points earned</span>
            </div>
            <div className="w-full h-2 bg-white rounded-full overflow-hidden mb-2">
              <div 
                className="h-full bg-[#1ca152] rounded-full transition-all duration-500" 
                style={{ width: `${progressPercentage}%` }}
              ></div>
            </div>
            <div className="flex items-center gap-2 text-xs mt-1 text-[#121416]">
              {isLoading ? (
                'Loading community stats...'
              ) : (
                <>
                  Join {stats?.total_users || 0}+ contributors making a real impact on Wikipedia.
                </>
              )}
            </div>
          </div>
          <div className="flex gap-4">
            <button 
              onClick={handleStartContributing}
              className="bg-[#121416] text-white font-bold rounded-xl px-7 py-3 text-base hover:bg-[#23272f] transition"
            >
              {isLoggedIn ? 'Start New Task' : 'Start Contributing'}
            </button>
            <button 
              onClick={handleLearnMore}
              className="bg-white border border-[#121416] text-[#121416] font-semibold rounded-xl px-7 py-3 text-base hover:bg-[#f1f2f4] transition"
            >
              Learn How It Works
            </button>
          </div>
        </div>
        {/* Right Side */}
        <div className="flex-1 min-w-[320px] ml-20 mt-20">
          <Image 
            src="/hero.png"
            alt="Wikipedia Fact Checking"
            width={600}
            height={400}
            className="w-full h-auto rounded-2xl"
```

---

**🧑‍🚒 Response (10)**: 

**👀‍ Observation (10)**:
```
Traceback (most recent call last):
  File "/root/tools/edit_anthropic/bin/str_replace_editor", line 18, in <module>
    from registry import registry as REGISTRY
ModuleNotFoundError: No module named 'registry'
```

---

**🧑‍🚒 Response (11)**: 

**👀‍ Observation (11)**:
```
Traceback (most recent call last):
  File "/root/tools/edit_anthropic/bin/str_replace_editor", line 18, in <module>
    from registry import registry as REGISTRY
ModuleNotFoundError: No module named 'registry'
```

---

**🧑‍🚒 Response (12)**: 

**👀‍ Observation (12)**:
```

```

---

**🧑‍🚒 Response (13)**: 

**👀‍ Observation (13)**:
```

```

---

**🧑‍🚒 Response (14)**: 

**👀‍ Observation (14)**:
```

```

---

**🧑‍🚒 Response (15)**: 

**👀‍ Observation (15)**:
```
153:          <div className="rounded-2xl border border-[#f1f2f4] p-6 mb-6 bg-[#f1f2f4]">
162:            <div className="w-full h-2 bg-white rounded-full overflow-hidden mb-2">
164:                className="h-full bg-[#2563eb] rounded-full transition-all duration-500" 
181:              className="bg-[#121416] text-white font-bold rounded-xl px-7 py-3 text-base hover:bg-[#23272f] transition"
187:              className="bg-white border border-[#121416] text-[#121416] font-semibold rounded-xl px-7 py-3 text-base hover:bg-[#f1f2f4] transition"
```

---

**🧑‍🚒 Response (16)**: 

**👀‍ Observation (16)**:
```

```

---

**🧑‍🚒 Response (17)**: 

**👀‍ Observation (17)**:
```

```

---

**🧑‍🚒 Response (18)**: 

**👀‍ Observation (18)**:
```
143	            </span>
   144	          </div>
   145	          <h1 className="text-5xl font-bold text-[#121416] mb-6 leading-tight tracking-tight">
   146	            {userName ? `Hi ${userName}, Help Improve Wikipedia` : 'Help Improve Wikipedia'}
   147	          </h1>
   148	          <p className="text-lg text-[#121416] mb-8 font-normal">
   149	            Join Stanford researchers in fixing millions of inconsistencies in Wikipedia. 
   150	            Your contributions will directly improve the world&apos;s largest knowledge base 
   151	            and earn you rewards for your impact.
   152	          </p>
   153	          <div className="rounded-2xl border border-[#f1f2f4] p-6 mb-6 bg-[#f1f2f4]">
   154	            <div className="flex items-center justify-between mb-2">
   155	              <span className="font-bold text-[#121416]">Goal: Fix 100 Inconsistencies</span>
   156	              <span className="text-xs text-[#121416] font-medium">{Math.round(progressPercentage)}% complete</span>
   157	            </div>
   158	            <div className="text-xs text-[#121416] mb-1 flex justify-between">
   159	              <span>{stats?.total_completed_tasks || 0} tasks completed</span>
   160	              <span>{stats?.total_points_awarded || 0} points earned</span>
   161	            </div>
   162	            <div className="w-full h-2 bg-white rounded-full overflow-hidden mb-2">
   163	              <div
```

---

**🧑‍🚒 Response (19)**: 
**Summary of findings so far:**
- The progress bar referenced in the PR is in `/frontend/src/components/Hero.tsx` at the div:
  ```jsx
  <div className="rounded-2xl border border-[#f1f2f4] p-6 mb-6 bg-[#f1f2f4]">
  ```
- The actual progress bar color was set by:
  ```jsx
  <div className="h-full bg-[#1ca152] rounded-full transition-all duration-500" ...>
  ```
  where `#1ca152` is a green color.
- The PR requests that this progress bar be blue, not green.

**Action taken:**
- I replaced `bg-[#1ca152]` with `bg-[#2563eb]` (a standard Tailwind blue) in the file using `sed`.

**Verification:**
- The code now contains `bg-[#2563eb]` for the progress bar, and no longer contains the green color.

---

## Next Steps

### 1. Reproduction Script

Since this is a UI change, a Python script cannot directly "see" the color. However, I can write a script to parse the file and confirm the color class is set to blue for the progress bar.

### 2. Edge Cases

- The only progress bar in this component is affected.
- The change is minimal and only affects the color.
- No other progress bars in the codebase use the same green color.

### 3. Final Verification

I will write a script to confirm that the progress bar color is now blue in the relevant file.

---

**Creating the verification script...**
**👀‍ Observation (19)**:
```
Traceback (most recent call last):
  File "/root/tools/edit_anthropic/bin/str_replace_editor", line 18, in <module>
    from registry import registry as REGISTRY
ModuleNotFoundError: No module named 'registry'
```

---

**🧑‍🚒 Response (20)**: 

**👀‍ Observation (20)**:
```

```

---

**🧑‍🚒 Response (21)**: 

**👀‍ Observation (21)**:
```
PASS: Progress bar is blue (#2563eb) and not green (#1ca152).
```

---

**🧑‍🚒 Response (22)**: 
**The issue is resolved!**

### What was done:
- The progress bar in the UI (in `/frontend/src/components/Hero.tsx`) was changed from green (`#1ca152`) to blue (`#2563eb`) as requested in the PR.
- A verification script confirmed that the progress bar is now blue and not green.

### Edge Cases:
- Only the relevant progress bar was changed.
- No other progress bars or UI elements were affected.

**If you need a visual confirmation, you can now run the frontend and see the blue progress bar. No further code changes are needed for this PR.**
**👀‍ Observation (22)**:
```

```

---

**🧑‍🚒 Response (23)**: 

**👀‍ Observation (23)**:
```
diff --git a/frontend/src/components/Hero.tsx b/frontend/src/components/Hero.tsx
index fc3ebe7..7d474fd 100644
--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -161,7 +161,7 @@ export default function Hero() {
             </div>
             <div className="w-full h-2 bg-white rounded-full overflow-hidden mb-2">
               <div 
-                className="h-full bg-[#1ca152] rounded-full transition-all duration-500" 
+                className="h-full bg-[#2563eb] rounded-full transition-all duration-500" 
                 style={{ width: `${progressPercentage}%` }}
               ></div>
             </div>
diff --git a/verify_progress_bar_color.py b/verify_progress_bar_color.py
new file mode 100644
index 0000000..baa39f3
--- /dev/null
+++ b/verify_progress_bar_color.py
@@ -0,0 +1,16 @@
+import sys
+
+FILE = 'frontend/src/components/Hero.tsx'
+EXPECTED = 'bg-[#2563eb]'
+UNEXPECTED = 'bg-[#1ca152]'
+
+with open(FILE) as f:
+    content = f.read()
+
+if EXPECTED in content and UNEXPECTED not in content:
+    print('PASS: Progress bar is blue (#2563eb) and not green (#1ca152).')
+    sys.exit(0)
+else:
+    print('FAIL: Progress bar color is incorrect.')
+    sys.exit(1)
+
```
</details>